### PR TITLE
COREP-3458 Do not reuse JAXB unmarshaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.0.19]
+
+- Fix multi-threading issues while parsing XML documents 
+
 ## [1.0.18]
 
-Restores `Description` in `/getTerminals` response to be able to customize the display of payment methods (originally introduced in 1.0.15)
+- Restores `Description` in `/getTerminals` response to be able to customize the display of payment methods (originally introduced in 1.0.15)
 
 ## [1.0.17]
 

--- a/build.xml
+++ b/build.xml
@@ -6,7 +6,7 @@
 	<property name="xsdUrl" value="https://testgateway.pensio.com/" />
 	<property name="outputdirs" value="build,devbuild,output,dependencylib,generated" />
 	<property name="local_dependencies" value="" />
-	<property name="altapay.release" value="1.0.18" />
+	<property name="altapay.release" value="1.0.19" />
 
 	<path id="CompileSource_classpath">
 		<fileset dir="lib/" includes="*.jar" />

--- a/src/com/pensio/api/PensioAbstractAPI.java
+++ b/src/com/pensio/api/PensioAbstractAPI.java
@@ -18,7 +18,7 @@ public abstract class PensioAbstractAPI {
 	protected String baseURL;
 	protected String username;
 	protected String password;
-	protected Unmarshaller u = null;
+	protected JAXBContext jc;
 
 	protected HTTPHelper httpHelper;
 
@@ -31,13 +31,16 @@ public abstract class PensioAbstractAPI {
 
 		try 
 		{
-			JAXBContext jc = JAXBContext.newInstance("com.pensio.api.generated");
-			u = jc.createUnmarshaller();
+			this.jc = JAXBContext.newInstance("com.pensio.api.generated");
 		}
 		catch (JAXBException e) 
 		{
 			e.printStackTrace();
 		}
+	}
+
+	protected Unmarshaller getUnmarshaller() throws JAXBException {
+		return this.jc.createUnmarshaller();
 	}
 
 	protected String getSdkVersion()
@@ -53,7 +56,7 @@ public abstract class PensioAbstractAPI {
 			InputStream inStream = this.httpHelper.doPost(this.baseURL+getAppAPIPath()+method, params, username, password, getSdkVersion());
 			
 			@SuppressWarnings("unchecked")
-			JAXBElement<APIResponse> result = (JAXBElement<APIResponse>)u.unmarshal(inStream);
+			JAXBElement<APIResponse> result = (JAXBElement<APIResponse>)getUnmarshaller().unmarshal(inStream);
 			
 			APIResponse response = result.getValue();
 			

--- a/src/com/pensio/api/PensioMerchantAPI.java
+++ b/src/com/pensio/api/PensioMerchantAPI.java
@@ -381,7 +381,7 @@ public class PensioMerchantAPI extends PensioAbstractAPI
 			}
 
 			@SuppressWarnings("unchecked")
-			JAXBElement<APIResponse> result = (JAXBElement<APIResponse>)u.unmarshal(inStream);
+			JAXBElement<APIResponse> result = (JAXBElement<APIResponse>)getUnmarshaller().unmarshal(inStream);
 			
 			APIResponse response = result.getValue();
 			
@@ -428,7 +428,7 @@ public class PensioMerchantAPI extends PensioAbstractAPI
 		try
 		{
 			@SuppressWarnings("unchecked")
-			JAXBElement<APIResponse> result = (JAXBElement<APIResponse>)u.unmarshal(new StringReader(xmlParameter));
+			JAXBElement<APIResponse> result = (JAXBElement<APIResponse>)getUnmarshaller().unmarshal(new StringReader(xmlParameter));
 			return result.getValue();
 		}
 		catch (JAXBException e)


### PR DESCRIPTION
JAXB unmarshaller is not thread safe and should not be reused in different threads.
This changes is making sure we create a new unmarshaller instance every time we need it, but keeping the single JAXBContext PensioMerchantAPI instance.